### PR TITLE
IP-1622. URL Type > Allow to set a text for the link

### DIFF
--- a/test4.txt
+++ b/test4.txt
@@ -1,0 +1,1 @@
+test doc


### PR DESCRIPTION
Sometimes the link can be dificult to read. So it would be good to allow to enter a text for the link.

In order to avoid changing the data structure what I would do is to use the wiki format:

```
<text>(link)
```

So when rendering a URL field we need to detect it and build the link correctly. Also we need to update validations for URL fields.

We also need to update the edit view of the URL type so it makes it easy to set the link name. Currently it is just an input where you can put the link. We should allow to set the link name to, which should default to URL if not specified. Let's see how this can be done without taking much space so it doesn't become bothering to the user.